### PR TITLE
Put `use v6.c` as the first line

### DIFF
--- a/lib/Binary/Structured.pm6
+++ b/lib/Binary/Structured.pm6
@@ -1,4 +1,3 @@
-use v6;
 use v6.c;
 
 =begin pod


### PR DESCRIPTION
By removing unnecessary `use v6`. Otherwise rakudo versions from the
future give this error:

    Too late to switch language version. Must be used as the very first statement.